### PR TITLE
feat(create-transfer): using options arg to set timeout

### DIFF
--- a/lib/finix.ex
+++ b/lib/finix.ex
@@ -37,7 +37,7 @@ defmodule FinixElixir do
   def make_request(method, endpoint, body \\ "", headers \\ [], options \\ []) do
     options =
       options
-      |> Keyword.put(:recv_timeout, 30_000)
+      |> Keyword.put(:recv_timeout, options[:timeout] || 30_000)
       |> Keyword.put(:ssl, [
         {:versions, [:"tlsv1.2", :"tlsv1.3", :"tlsv1.1", :tlsv1]},
         {:verify, :verify_none}

--- a/lib/finix/transfers.ex
+++ b/lib/finix/transfers.ex
@@ -10,8 +10,8 @@ defmodule Finix.Transfers do
   @endpoint "transfers"
 
   @spec create(map(), Keyword.t()) :: {:error, map()} | {:ok, map()}
-  def create(params, header_opts \\ []) do
-    FinixElixir.make_request(:post, @endpoint, params, header_opts)
+  def create(params, header_opts \\ [], options \\ []) do
+    FinixElixir.make_request(:post, @endpoint, params, header_opts, options)
   end
 
   @spec get(String.t(), Keyword.t()) :: {:ok, map()} | {:error, map()}


### PR DESCRIPTION
## Description

This PR includes an timeout option to the `Finix.Transfer.create` call. The default value still is 30 seconds (if blank), but it uses the received value if there is one.
